### PR TITLE
docs: correct stale Skills section, adopt global-only wiring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,17 +211,9 @@ The app recently migrated to Material 3. When working with text visibility issue
 
 ## Skills
 
-Skills live in `.claude/skills/`. Shared skills come from the `agentic-grappim`
-git submodule at `.claude/agentic-grappim/`.
-
-**After cloning**, initialize the submodule to make shared skills available:
-
-```bash
-git submodule update --init
-```
-
-| Skill | Usage | Description |
-|-------|-------|-------------|
-| `navigation-3` | auto-loaded | Google's official Navigation 3 recipes |
-| `edge-to-edge` | auto-loaded | System bars, insets, IME for SDK 35+ |
-| `adaptive` | auto-loaded | Adaptive layouts for tablets/foldables |
+Skills and agents are wired up **per machine, not per clone**, via symlinks into
+`~/.claude/skills/` and `~/.claude/agents/` — there is nothing in this repo to install,
+and `.claude/skills/` here holds none of its own. `navigation-3`, `edge-to-edge`, and
+`adaptive` are first-party `android-skills:*` skills, available every session with no
+wiring at all; anything from the `agentic-grappim` repo (`finalize`, `masvs-review`,
+`emulator-testing`, etc.) is linked globally the same way.


### PR DESCRIPTION
## Summary
- The `## Skills` section described a git submodule at `.claude/agentic-grappim/` that never existed on disk (no `.gitmodules`, no such directory) — leftover from planning that was never implemented.
- Replaces it with what's actually true: skills/agents are symlinked per-machine into `~/.claude/skills/`, same convention as wallosmobile/TaigaMobileNova, and `navigation-3`/`edge-to-edge`/`adaptive` are first-party `android-skills:*`, not from `agentic-grappim`.
- Part of grappim-watcher checklist step 4 (pick one skill-wiring convention machine-wide).

## Test plan
- [x] `.claude/skills/` doesn't exist in this repo (confirmed) — doc now matches
- [x] Doc reviewed for accuracy against actual `~/.claude/skills/` contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xm8kXekzgH2zTodZAjKDtV